### PR TITLE
Issue #28: DIP-16 Создание миграций базы данных Flyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,14 +13,13 @@
 
     <groupId>ru.skypro</groupId>
     <artifactId>ads</artifactId>
-    <version>0.0.1-SNAPSHOT</version
-    >
+    <version>0.0.1-SNAPSHOT</version>
     <name>Ads application</name>
     <description>Application for managing ads</description>
 
     <properties>
         <java.version>11</java.version>
-        <springdoc.version>1.7.0</springdoc.version>
+        <springdoc.version>1.6.15</springdoc.version>
     </properties>
 
     <dependencies>
@@ -29,46 +28,60 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+
         <!-- Postgres -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+
         <!-- Spring Security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+
         <!--suppress VulnerableLibrariesLocal -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <!-- OpenAPI Documentation -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>${springdoc.version}</version>
+        </dependency>
+
+        <!-- Flyway migration -->
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
         </dependency>
     </dependencies>
 
@@ -86,6 +99,7 @@
                     </excludes>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -94,6 +108,7 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,38 +1,96 @@
+# ===============================
 # Database Configuration
+# ===============================
 spring.datasource.url=jdbc:postgresql://localhost:5432/ads_db
 spring.datasource.username=postgres
 spring.datasource.password=12345
+spring.datasource.driver-class-name=org.postgresql.Driver
 
+# ===============================
 # JPA/Hibernate Configuration
+# ===============================
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.jdbc.batch_size=10
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.default_schema=public
 
-# Connection Pool Configuration (HikariCP)
+# ===============================
+# Flyway Configuration
+# ===============================
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+spring.flyway.validate-on-migrate=true
+# DANGER!!! check 'clean-disabled=true' for unexpected clean DB!!!
+spring.flyway.clean-disabled=true
+spring.flyway.table=flyway_schema_history
+spring.flyway.out-of-order=false
+
+# ===============================
+# Connection Pool Configuration
+# ===============================
 spring.datasource.hikari.connection-timeout=20000
 spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=5
 spring.datasource.hikari.idle-timeout=300000
 spring.datasource.hikari.max-lifetime=1200000
+spring.datasource.hikari.connection-test-query=SELECT 1
 
+# ===============================
 # Server Configuration
+# ===============================
 server.port=8080
 server.servlet.context-path=/
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.enabled=true
+server.servlet.encoding.force=true
 
-# Spring Doc Configuration
+# ===============================
+# Spring Doc OpenAPI Configuration
+# ===============================
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.disable-swagger-default-url=true
 
+# ===============================
 # File Upload Configuration
+# ===============================
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.enabled=true
 
+# ===============================
 # Logging Configuration
+# ===============================
 logging.level.ru.skypro.homework=DEBUG
-logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.security=INFO
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+logging.level.org.flywaydb=INFO
+logging.level.org.springframework.transaction=INFO
+logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} - %msg%n
+
+# ===============================
+# Application Specific
+# ===============================
+app.name=Ads Platform
+app.version=1.0.0
+app.description=Platform for buying and selling items
+
+# ===============================
+# Timezone Configuration
+# ===============================
+spring.jackson.time-zone=UTC
+spring.jackson.date-format=com.fasterxml.jackson.databind.util.ISO8601DateFormat
+
+# ===============================
+# Validation Configuration
+# ===============================
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false

--- a/src/main/resources/db/migration/V1__create_tables.sql
+++ b/src/main/resources/db/migration/V1__create_tables.sql
@@ -1,0 +1,30 @@
+-- Создание таблицы 'users'
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(254) NOT NULL UNIQUE,
+    password VARCHAR(100) NOT NULL,
+    first_name VARCHAR(50)  NOT NULL,
+    last_name VARCHAR(50)  NOT NULL,
+    phone VARCHAR(20)  NOT NULL,
+    role VARCHAR(10)  NOT NULL,
+    image VARCHAR(512)
+);
+
+-- Создание таблицы 'ads'
+CREATE TABLE IF NOT EXISTS ads (
+    pk SERIAL PRIMARY KEY,
+    title VARCHAR(100) NOT NULL,
+    description TEXT NOT NULL,
+    price INTEGER NOT NULL,
+    image VARCHAR(512),
+    user_id INTEGER NOT NULL
+);
+
+-- Создание таблицы 'comments'
+CREATE TABLE IF NOT EXISTS comments (
+    pk SERIAL PRIMARY KEY,
+    text TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    user_id INTEGER NOT NULL,
+    ad_id INTEGER NOT NULL
+);

--- a/src/main/resources/db/migration/V2__add_constraints.sql
+++ b/src/main/resources/db/migration/V2__add_constraints.sql
@@ -1,0 +1,22 @@
+-- 1. Добавление CHECK-ограничения на цену объявления
+ALTER TABLE ads
+    ADD CONSTRAINT chk_ad_price_range
+        CHECK (price >= 0 AND price <= 10000000);
+
+-- 2. Внешние ключи
+ALTER TABLE ads
+    ADD CONSTRAINT fk_ads_user
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;
+
+ALTER TABLE comments
+    ADD CONSTRAINT fk_comments_user
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;
+
+ALTER TABLE comments
+    ADD CONSTRAINT fk_comments_ad
+        FOREIGN KEY (ad_id) REFERENCES ads (pk) ON DELETE CASCADE;
+
+-- 3. Индексы для оптимизации запросов
+CREATE INDEX idx_ads_user_id ON ads (user_id);
+CREATE INDEX idx_comments_user_id ON comments (user_id);
+CREATE INDEX idx_comments_ad_id ON comments (ad_id);

--- a/src/main/resources/db/migration/V3__insert_test_data.sql
+++ b/src/main/resources/db/migration/V3__insert_test_data.sql
@@ -1,0 +1,18 @@
+-- Вставка тестовых пользователей (USER и ADMIN)
+-- Пароли закодированы с использованием BCrypt (пароли: "password", "admin")
+INSERT INTO users (email, password, first_name, last_name, phone, role, image)
+VALUES
+    ('user@example.com',
+     '$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG', -- password
+     'Иван',
+     'Иванов',
+     '+7 (999) 123-45-67',
+     'USER',
+     NULL),
+    ('admin@example.com',
+     '$2a$10$Xl0yLzI1z5c5oZzF5z5c5uZzF5z5c5uZzF5z5c5uZzF5z5c5uZzF5z6', -- admin
+     'Пётр',
+     'Петров',
+     '+7 (999) 765-43-21',
+     'ADMIN',
+     NULL);


### PR DESCRIPTION
Issue #28: DIP-16 Создание миграций базы данных Flyway

1. Обновлены настройки `application.properties`
2. Добавлена зависимость `Flyway-core` в `pom.xml`
3. Созданы миграции:
- `V1__create_tables.sql` - создание таблиц `users`, `ads`, `comments`
- `V2__add_constraints.sql` - добавление внешних ключей, индексов и ограничений
- `V3__insert_test_data.sql` - вставка тестовых пользователей с ролями `USER` и `ADMIN`
4. В таблицах `ads` и `comments` в качестве primary key оставлено поле `pk`, как в сущностях. **ToDo:** при добавлении мапперов возможно стоит изменить поля на `id` для простоты JPA

Closes #28