### PR TITLE
Issue #32: DIP-20 Настройка MapStruct в проекте

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.7.15</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath/>
     </parent>
 
     <groupId>ru.skypro</groupId>
@@ -20,6 +20,8 @@
     <properties>
         <java.version>11</java.version>
         <springdoc.version>1.6.15</springdoc.version>
+        <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+        <lombok.version>1.18.28</lombok.version>
     </properties>
 
     <dependencies>
@@ -83,6 +85,21 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
+
+        <!-- MapStruct -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${org.mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -103,9 +120,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 

--- a/src/main/java/ru/skypro/homework/config/MapStructConfig.java
+++ b/src/main/java/ru/skypro/homework/config/MapStructConfig.java
@@ -1,0 +1,11 @@
+package ru.skypro.homework.config;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+
+@MapperConfig(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface MapStructConfig {
+}


### PR DESCRIPTION
Issue #32: DIP-20 Настройка MapStruct в проекте

1.`pom.xml` (добавление зависимостей + совместимость версий):
- добавлены зависимости `mapstruct`и `mapstruct-processor`
- добавлено свойство `org.mapstruct.version`
- добавлено свойство `lombok.version`
- добавлена конфигурация `maven-compiler-plugin` с `annotationProcessorPath`
2. `MapStructConfig.java` - создан конфигурационный интерфейс с аннотацией `@MapperConfig`, задающий `componentModel = "Spring"` и политику обработки несопоставленных полей (`IGNORE`)

Closes #32