### PR TITLE
Issue #33: DIP-21 Настройка UserMapper с маппингом полей

### DIFF
--- a/src/main/java/ru/skypro/homework/controller/user/UserController.java
+++ b/src/main/java/ru/skypro/homework/controller/user/UserController.java
@@ -26,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 import ru.skypro.homework.dto.auth.Role;
 import ru.skypro.homework.dto.user.NewPassword;
 import ru.skypro.homework.dto.user.UpdateUser;
-import ru.skypro.homework.dto.user.User;
+import ru.skypro.homework.dto.user.UserDto;
 
 import javax.validation.Valid;
 
@@ -81,28 +81,28 @@ public class UserController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = User.class))),
+                                        schema = @Schema(implementation = UserDto.class))),
                 @ApiResponse(
                         responseCode = "401",
                         description = "Пользователь не авторизован",
                         content = @Content(schema = @Schema(hidden = true)))
             })
     @GetMapping("/me")
-    public ResponseEntity<User> getUser(Authentication authentication) {
+    public ResponseEntity<UserDto> getUser(Authentication authentication) {
 
         log.info("Запрос информации о пользователе");
 
         // Заглушка - возвращаем DTO с дефолтными значениями
-        User user = new User();
-        user.setId(1);
-        user.setEmail("user@example.com");
-        user.setFirstName("Иван");
-        user.setLastName("Иванов");
-        user.setPhone("+7 (999) 123-45-67");
-        user.setRole(Role.USER);
-        user.setImage("/images/avatar.jpg");
+        UserDto userDto = new UserDto();
+        userDto.setId(1);
+        userDto.setEmail("userDto@example.com");
+        userDto.setFirstName("Иван");
+        userDto.setLastName("Иванов");
+        userDto.setPhone("+7 (999) 123-45-67");
+        userDto.setRole(Role.USER);
+        userDto.setImage("/images/avatar.jpg");
 
-        return ResponseEntity.ok(user);
+        return ResponseEntity.ok(userDto);
     }
 
     @Operation(

--- a/src/main/java/ru/skypro/homework/dto/user/UserDto.java
+++ b/src/main/java/ru/skypro/homework/dto/user/UserDto.java
@@ -8,7 +8,7 @@ import ru.skypro.homework.dto.auth.Role;
 
 @Data
 @Schema(description = "DTO для отображения информации о пользователе")
-public class User {
+public class UserDto {
 
     @Schema(description = "ID пользователя", example = "1")
     private Integer id;

--- a/src/main/java/ru/skypro/homework/mapper/UserMapper.java
+++ b/src/main/java/ru/skypro/homework/mapper/UserMapper.java
@@ -1,0 +1,28 @@
+package ru.skypro.homework.mapper;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import ru.skypro.homework.config.MapStructConfig;
+import ru.skypro.homework.dto.auth.Register;
+import ru.skypro.homework.dto.user.UpdateUser;
+import ru.skypro.homework.dto.user.UserDto;
+import ru.skypro.homework.model.User;
+
+@Mapper(config = MapStructConfig.class)
+public interface UserMapper {
+
+    UserDto toUserDto(User entity);
+
+    @Mapping(source = "username", target = "email")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "image", ignore = true)
+    @Mapping(target = "ads", ignore = true)
+    @Mapping(target = "comments", ignore = true)
+    User toUserEntity(Register registerDto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateUserFromDto(UpdateUser dto, @MappingTarget User entity);
+}


### PR DESCRIPTION
Issue #33: DIP-21 Настройка UserMapper с маппингом полей

1. Из-за конфликта имен в импортах `DTO User` переименовано в `UserDto`. `Entity User` остается "чистой". Рикошетом обновился `UserController`, из-за `UserDto`, никаких других изменений в API нет.
2. Настроена политика игнорирования полей:
- `id` - генерируется БД
- `image` - при регистрации пользователя null
- `ads` - у пользователя на данном этапе нет объявлений
- `comments` - у пользователя на данном этапе нет комментариев

**Важно!** Поля `id`, `image`, `ads`, `comments` не должны устанавливаться из DTO регистрации, `ignore = true` гарантирует это.

3. `NullValuePropertyMappingStrategy.IGNORE` в методе `UpdateUserFromDto` проигнорирует пустые (не переданные) поля и заапдейтит только то что передано.

Closes #33