### PR TITLE
Issue #34: DIP-22 Настройка AdMapper с маппингом полей

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -150,7 +150,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Ad'
+                $ref: '#/components/schemas/AdDto'
         '401':
           description: Unauthorized
   /ads/{id}/comments:
@@ -275,7 +275,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Ad'
+                $ref: '#/components/schemas/AdDto'
         '403':
           description: Forbidden
         '401':
@@ -593,7 +593,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Ad'
+            $ref: '#/components/schemas/AdDto'
     ExtendedAd:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <implicit>none</implicit>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/src/main/java/ru/skypro/homework/controller/ad/AdController.java
+++ b/src/main/java/ru/skypro/homework/controller/ad/AdController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import ru.skypro.homework.dto.ad.Ad;
+import ru.skypro.homework.dto.ad.AdDto;
 import ru.skypro.homework.dto.ad.Ads;
 import ru.skypro.homework.dto.ad.CreateOrUpdateAd;
 import ru.skypro.homework.dto.ad.ExtendedAd;
@@ -76,20 +76,20 @@ public class AdController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = Ad.class))),
+                                        schema = @Schema(implementation = AdDto.class))),
                 @ApiResponse(
                         responseCode = "401",
                         description = "Пользователь не авторизован",
                         content = @Content)
             })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Ad> addAd(
+    public ResponseEntity<AdDto> addAd(
             @RequestPart("properties") @Valid CreateOrUpdateAd properties,
             @RequestPart("image") MultipartFile image,
             Authentication authentication) {
         log.info("Запрос на создание объявления");
         // Заглушка
-        Ad ad = new Ad();
+        AdDto ad = new AdDto();
         return ResponseEntity.status(HttpStatus.CREATED).body(ad);
     }
 
@@ -162,7 +162,7 @@ public class AdController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = Ad.class))),
+                                        schema = @Schema(implementation = AdDto.class))),
                 @ApiResponse(
                         responseCode = "401",
                         description = "Пользователь не авторизован",
@@ -177,13 +177,13 @@ public class AdController {
                         content = @Content)
             })
     @PatchMapping("/{id}")
-    public ResponseEntity<Ad> updateAd(
+    public ResponseEntity<AdDto> updateAd(
             @Parameter(description = "ID объявления") @PathVariable Integer id,
             @Valid @RequestBody CreateOrUpdateAd updateAd,
             Authentication authentication) {
         log.info("Запрос на обновление объявления с ID: {}", id);
         // Заглушка
-        Ad ad = new Ad();
+        AdDto ad = new AdDto();
         return ResponseEntity.ok(ad);
     }
 

--- a/src/main/java/ru/skypro/homework/dto/ad/AdDto.java
+++ b/src/main/java/ru/skypro/homework/dto/ad/AdDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Data
 @Schema(description = "Базовая информация об объявлении")
-public class Ad {
+public class AdDto {
 
     @Schema(description = "ID автора объявления", example = "1")
     private Integer author;

--- a/src/main/java/ru/skypro/homework/dto/ad/Ads.java
+++ b/src/main/java/ru/skypro/homework/dto/ad/Ads.java
@@ -14,5 +14,5 @@ public class Ads {
     private Integer count;
 
     @Schema(description = "Список объявлений")
-    private List<Ad> results;
+    private List<AdDto> results;
 }

--- a/src/main/java/ru/skypro/homework/mapper/AdMapper.java
+++ b/src/main/java/ru/skypro/homework/mapper/AdMapper.java
@@ -1,0 +1,34 @@
+package ru.skypro.homework.mapper;
+
+import ru.skypro.homework.config.MapStructConfig;
+import ru.skypro.homework.dto.ad.AdDto;
+import ru.skypro.homework.dto.ad.CreateOrUpdateAd;
+import ru.skypro.homework.dto.ad.ExtendedAd;
+import ru.skypro.homework.model.Ad;
+import org.mapstruct.*;
+
+@Mapper(config = MapStructConfig.class)
+public interface AdMapper {
+
+    @Mapping(source = "author.id", target = "author")
+    AdDto toAdDto(Ad entity);
+
+    @Mapping(source = "author.firstName", target = "authorFirstName")
+    @Mapping(source = "author.lastName", target = "authorLastName")
+    @Mapping(source = "author.email", target = "email")
+    @Mapping(source = "author.phone", target = "phone")
+    ExtendedAd toExtendedAdDto(Ad entity);
+
+    @Mapping(target = "pk", ignore = true)
+    @Mapping(target = "image", ignore = true)
+    @Mapping(target = "author", ignore = true)
+    @Mapping(target = "comments", ignore = true)
+    Ad toAdEntity(CreateOrUpdateAd dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "pk", ignore = true)
+    @Mapping(target = "image", ignore = true)
+    @Mapping(target = "author", ignore = true)
+    @Mapping(target = "comments", ignore = true)
+    void updateAdFromDto(CreateOrUpdateAd dto, @MappingTarget Ad entity);
+}


### PR DESCRIPTION
Issue #34: DIP-22 Настройка AdMapper с маппингом полей

1. Из-за конфликта имен в импортах `DTO Ad` переименовано в `AdDto`. `Entity Ad` остается "чистой". Рикошетом обновился `AdController` и `openapi.yaml` из-за `AdDto`, никаких других изменений в API и OpenAPI нет.
2. Настроена политика игнорирования полей
3. `NullValuePropertyMappingStrategy.IGNORE` в методе `updateAdFromDto` проигнорирует пустые (не переданные) поля и заапдейтит только то что передано.
4. В `pom.xml` добавлен параметр `<implicit>` запрещающий неявную компиляцию файлов, не указанных явно, так же убирает предупреждение, которое постоянно выскакивало при перекомпиляции проекта. Не влияет на работу приложения.

Closes #34