### PR TITLE
Issue #35: DIP-23 Настройка CommentMapper с маппингом полей

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -201,7 +201,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Comment'
+                $ref: '#/components/schemas/CommentDto'
         '401':
           description: Unauthorized
         '404':
@@ -339,7 +339,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/Comment'
+                $ref: '#/components/schemas/CommentDto'
         '403':
           description: Forbidden
         '401':
@@ -636,4 +636,4 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Comment'
+            $ref: '#/components/schemas/CommentDto'

--- a/src/main/java/ru/skypro/homework/controller/comment/CommentController.java
+++ b/src/main/java/ru/skypro/homework/controller/comment/CommentController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import ru.skypro.homework.dto.comment.Comment;
+import ru.skypro.homework.dto.comment.CommentDto;
 import ru.skypro.homework.dto.comment.Comments;
 import ru.skypro.homework.dto.comment.CreateOrUpdateComment;
 
@@ -79,7 +79,7 @@ public class CommentController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = Comment.class))),
+                                        schema = @Schema(implementation = CommentDto.class))),
                 @ApiResponse(
                         responseCode = "401",
                         description = "Пользователь не авторизован",
@@ -90,13 +90,13 @@ public class CommentController {
                         content = @Content)
             })
     @PostMapping("/{adId}/comments")
-    public ResponseEntity<Comment> addComment(
+    public ResponseEntity<CommentDto> addComment(
             @Parameter(description = "ID объявления") @PathVariable Integer adId,
             @Valid @RequestBody CreateOrUpdateComment createComment,
             Authentication authentication) {
         log.info("Запрос на добавление комментария к объявлению с ID: {}", adId);
         // Заглушка
-        Comment comment = new Comment();
+        CommentDto comment = new CommentDto();
         return ResponseEntity.ok(comment);
     }
 
@@ -140,7 +140,7 @@ public class CommentController {
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        schema = @Schema(implementation = Comment.class))),
+                                        schema = @Schema(implementation = CommentDto.class))),
                 @ApiResponse(
                         responseCode = "401",
                         description = "Пользователь не авторизован",
@@ -155,14 +155,14 @@ public class CommentController {
                         content = @Content)
             })
     @PatchMapping("/{adId}/comments/{commentId}")
-    public ResponseEntity<Comment> updateComment(
+    public ResponseEntity<CommentDto> updateComment(
             @Parameter(description = "ID объявления") @PathVariable Integer adId,
             @Parameter(description = "ID комментария") @PathVariable Integer commentId,
             @Valid @RequestBody CreateOrUpdateComment updateComment,
             Authentication authentication) {
         log.info("Запрос на обновление комментария с ID {} в объявлении с ID: {}", commentId, adId);
         // Заглушка
-        Comment comment = new Comment();
+        CommentDto comment = new CommentDto();
         return ResponseEntity.ok(comment);
     }
 }

--- a/src/main/java/ru/skypro/homework/dto/comment/CommentDto.java
+++ b/src/main/java/ru/skypro/homework/dto/comment/CommentDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Data
 @Schema(description = "Информация о комментарии")
-public class Comment {
+public class CommentDto {
 
     @Schema(description = "ID автора комментария", example = "1")
     private Integer author;

--- a/src/main/java/ru/skypro/homework/dto/comment/Comments.java
+++ b/src/main/java/ru/skypro/homework/dto/comment/Comments.java
@@ -14,5 +14,5 @@ public class Comments {
     private Integer count;
 
     @Schema(description = "Список комментариев")
-    private List<Comment> results;
+    private List<CommentDto> results;
 }

--- a/src/main/java/ru/skypro/homework/mapper/CommentMapper.java
+++ b/src/main/java/ru/skypro/homework/mapper/CommentMapper.java
@@ -1,0 +1,51 @@
+package ru.skypro.homework.mapper;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import ru.skypro.homework.config.MapStructConfig;
+import ru.skypro.homework.dto.comment.CommentDto;
+import ru.skypro.homework.dto.comment.CreateOrUpdateComment;
+import ru.skypro.homework.model.Comment;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Mapper(config = MapStructConfig.class)
+public interface CommentMapper {
+
+    @Mapping(source = "author.id", target = "author")
+    @Mapping(source = "author.image", target = "authorImage")
+    @Mapping(source = "author.firstName", target = "authorFirstName")
+    @Mapping(source = "createdAt", target = "createdAt", qualifiedByName = "localDateTimeToEpochMillis")
+    CommentDto toCommentDto(Comment entity);
+
+    @Mapping(target = "pk", ignore = true)
+    @Mapping(target = "createdAt", expression = "java(java.time.LocalDateTime.now())")
+    @Mapping(target = "author", ignore = true)
+    @Mapping(target = "ad", ignore = true)
+    Comment toCommentEntity(CreateOrUpdateComment dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "pk", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "author", ignore = true)
+    @Mapping(target = "ad", ignore = true)
+    void updateCommentFromDto(CreateOrUpdateComment dto, @MappingTarget Comment entity);
+
+    // ========== Вспомогательный метод: LocalDateTime → Long (epoch millis) ==========
+    @Named("localDateTimeToEpochMillis")
+    default Long localDateTimeToEpochMillis(LocalDateTime dateTime) {
+        if (dateTime == null) return null;
+        return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    default LocalDateTime epochMillisToLocalDateTime(Long epoch) {
+        if (epoch == null) return null;
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(epoch), ZoneOffset.UTC);
+    }
+}


### PR DESCRIPTION
Issue #35: DIP-23 Настройка CommentMapper с маппингом полей

1. Из-за конфликта имен в импортах `DTO Comment` переименовано в `CommentDto`. `Entity Comment` остается "чистой". Рикошетом обновился `CommentController`, `Comments` и `openapi.yaml` из-за `CommentDto`, никаких других изменений в API и OpenAPI нет.
2. Настроена политика игнорирования полей
3. `NullValuePropertyMappingStrategy.IGNORE` в методе `updateCommentFromDto` проигнорирует пустые (не переданные) поля и заапдейтит только то что передано.
4. Явно игнорируются `pk`, `createdAt`, `author`, `id` - эти поля не должны изменяться при обновлении текста.
5. Дата создания хранится в БД как `TIMESTAMP`(LocalDateTime), пользователю отдается как `Long` (в миллисекундах). Преобразование через вспомогательный метод.

Closes #35