### PR TITLE
Issue #65: DIP-26.1 Обновление сервиса AuthService

### DIFF
--- a/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
+++ b/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
@@ -1,61 +1,56 @@
 package ru.skypro.homework.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-import ru.skypro.homework.dto.auth.Role;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebSecurityConfig {
 
+    private final UserDetailsService userDetailsService;
+
     private static final String[] AUTH_WHITELIST = {
-        "/swagger-resources/**",
-        "/swagger-ui.html",
-        "/v3/api-docs",
-        "/webjars/**",
-        "/login",
-        "/register"
+            "/swagger-resources/**",
+            "/swagger-ui.html",
+            "/v3/api-docs",
+            "/webjars/**",
+            "/login",
+            "/register"
     };
 
     @Bean
-    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder passwordEncoder) {
-        UserDetails user =
-                User.builder()
-                        .username("user@gmail.com")
-                        .password("password")
-                        .passwordEncoder(passwordEncoder::encode)
-                        .roles(Role.USER.name())
-                        .build();
-        return new InMemoryUserDetailsManager(user);
-    }
-
-    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf()
-                .disable()
-                .authorizeHttpRequests(
-                        authorization ->
-                                authorization
-                                        .mvcMatchers(AUTH_WHITELIST)
-                                        .permitAll()
-                                        .mvcMatchers("/ads/**", "/users/**")
-                                        .authenticated())
-                .cors()
-                .and()
-                .httpBasic(withDefaults());
+        http.csrf().disable()
+            .authorizeHttpRequests(authz -> authz
+                    .mvcMatchers(AUTH_WHITELIST).permitAll()
+                    .mvcMatchers("/ads/**", "/users/**").authenticated()
+            )
+            .cors(withDefaults())
+            .httpBasic(withDefaults());
         return http.build();
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authManager(HttpSecurity http) throws Exception {
+        return http.getSharedObject(AuthenticationManagerBuilder.class)
+                   .userDetailsService(userDetailsService)
+                   .passwordEncoder(passwordEncoder())
+                   .and()
+                   .build();
     }
 }

--- a/src/main/java/ru/skypro/homework/controller/auth/AuthController.java
+++ b/src/main/java/ru/skypro/homework/controller/auth/AuthController.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,7 +21,6 @@ import javax.validation.Valid;
 
 @Slf4j
 @Validated
-@CrossOrigin(value = "http://localhost:3000")
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Авторизация", description = "API для регистрации и аутентификации пользователей")
@@ -30,65 +28,25 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(
-            summary = "Авторизация пользователя",
-            description = "Вход пользователя в систему с использованием логина и пароля")
-    @ApiResponses(
-            value = {
-                @ApiResponse(
-                        responseCode = "200",
-                        description = "Успешная авторизация",
-                        content = @Content),
-                @ApiResponse(
-                        responseCode = "400",
-                        description = "Некорректные данные запроса (ошибка валидации)",
-                        content = @Content),
-                @ApiResponse(
-                        responseCode = "401",
-                        description = "Неверные учетные данные (логин или пароль)",
-                        content = @Content)
-            })
+    @Operation(summary = "Авторизация пользователя")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Успешная авторизация", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Неверные учетные данные", content = @Content)
+    })
     @PostMapping("/login")
     public ResponseEntity<Void> login(@Valid @RequestBody LoginDto loginDto) {
-        log.info("Запрос на авторизацию пользователя: {}", loginDto.getUsername());
-
-        if (authService.login(loginDto.getUsername(), loginDto.getPassword())) {
-            log.info("Пользователь {} успешно авторизован", loginDto.getUsername());
-            return ResponseEntity.ok().build();
-        } else {
-            log.warn("Неудачная попытка авторизации для пользователя: {}", loginDto.getUsername());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+        authService.login(loginDto.getUsername(), loginDto.getPassword());
+        return ResponseEntity.ok().build();
     }
 
-    @Operation(
-            summary = "Регистрация пользователя",
-            description = "Создание нового пользователя в системе")
-    @ApiResponses(
-            value = {
-                @ApiResponse(
-                        responseCode = "201",
-                        description = "Пользователь успешно зарегистрирован",
-                        content = @Content),
-                @ApiResponse(
-                        responseCode = "400",
-                        description =
-                                "Некорректные данные запроса (ошибка валидации или пользователь уже существует)",
-                        content = @Content)
-            })
+    @Operation(summary = "Регистрация пользователя")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Пользователь успешно зарегистрирован", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Пользователь уже существует или некорректные данные", content = @Content)
+    })
     @PostMapping("/register")
     public ResponseEntity<Void> register(@Valid @RequestBody RegisterDto registerDto) {
-        log.info(
-                "Запрос на регистрацию пользователя: {} {}",
-                registerDto.getFirstName(),
-                registerDto.getLastName());
-
-        if (authService.register(registerDto)) {
-            log.info("Пользователь {} успешно зарегистрирован", registerDto.getUsername());
-            return ResponseEntity.status(HttpStatus.CREATED).build();
-        } else {
-            log.warn("Неудачная попытка регистрации пользователя: {}", registerDto.getUsername());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        }
+        authService.register(registerDto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/ru/skypro/homework/exception/UserAlreadyExistsException.java
+++ b/src/main/java/ru/skypro/homework/exception/UserAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package ru.skypro.homework.exception;
+
+public class UserAlreadyExistsException extends RuntimeException {
+    public UserAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
@@ -2,12 +2,14 @@ package ru.skypro.homework.handler;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import ru.skypro.homework.exception.AdNotFoundException;
 import ru.skypro.homework.exception.CommentNotFoundException;
 import ru.skypro.homework.exception.InvalidCurrentPasswordException;
 import ru.skypro.homework.exception.UnauthorizedAccessException;
+import ru.skypro.homework.exception.UserAlreadyExistsException;
 import ru.skypro.homework.exception.UserNotFoundException;
 
 @RestControllerAdvice
@@ -36,5 +38,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CommentNotFoundException.class)
     public ResponseEntity<?> handleCommentNotFound(CommentNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<?> handleBadCredentials() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<?> handleUserAlreadyExists(UserAlreadyExistsException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 }

--- a/src/main/java/ru/skypro/homework/service/AuthService.java
+++ b/src/main/java/ru/skypro/homework/service/AuthService.java
@@ -3,7 +3,21 @@ package ru.skypro.homework.service;
 import ru.skypro.homework.dto.auth.RegisterDto;
 
 public interface AuthService {
-    boolean login(String userName, String password);
 
-    boolean register(RegisterDto registerDto);
+    /**
+     * Аутентификация пользователя.
+     *
+     * @param userName логин (email)
+     * @param password пароль
+     * @throws org.springframework.security.authentication.BadCredentialsException если неверные учетные данные
+     */
+    void login(String userName, String password);
+
+    /**
+     * Регистрация нового пользователя.
+     *
+     * @param registerDto данные регистрации
+     * @throws ru.skypro.homework.exception.UserAlreadyExistsException если пользователь с таким email уже существует
+     */
+    void register(RegisterDto registerDto);
 }

--- a/src/main/java/ru/skypro/homework/service/CustomUserDetailsService.java
+++ b/src/main/java/ru/skypro/homework/service/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package ru.skypro.homework.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import ru.skypro.homework.model.UsersDao;
+import ru.skypro.homework.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UsersDao user = userRepository.findByEmail(username)
+                                      .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        return User.builder()
+                   .username(user.getEmail())
+                   .password(user.getPassword())
+                   .roles(user.getRole().name())
+                   .build();
+    }
+}


### PR DESCRIPTION
Issue #65: DIP-26.1 Обновление сервиса AuthService

1. Убрана зависимость от `InMemoryUserDetailManager`
2. Добавлен `CustomUserDetailsService`, который загружает пользователя из БД
3. `AuthServiceImpl` теперь использует `AuthenticationManager` для проверки логина и сохраняет новых пользователей в БД
4. Доступ к защищенным эндпоинтам (`/ads/**`, `/users/**`) возможен только после авторизации (внесены изменения в `WebSecurityConfig`)
5. `AuthService` теперь кидает исключения при ошибках, а не возвращает `boolean`
6. `AuthController` переписан и стал предельно тонким: вызывает методы сервиса и возвращает успешный статус. Вся логика обработки ошибок вынесена в `GlobalExceptionHandler`
7. `GlobalExceptionHandler` конвертирует исключения в правильные HTTP-ответы:
- `BadCredentialsException` возвращает 401 Unauthorized
- `UserAlreadyExistsException` (новое) возвращает 400 Bad Request

Closes #65  