### PR TITLE
Issue #88: DIP-35 Исправить обработку ошибок при смене пароля

### DIFF
--- a/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidCurrentPasswordException.class)
     public ResponseEntity<?> handleInvalidPassword(InvalidCurrentPasswordException e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
     @ExceptionHandler(AdNotFoundException.class)

--- a/src/test/java/ru/skypro/homework/controller/user/UserControllerIntegrationTest.java
+++ b/src/test/java/ru/skypro/homework/controller/user/UserControllerIntegrationTest.java
@@ -152,7 +152,7 @@ class UserControllerIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    void setPassword_WithWrongCurrent_ShouldReturnForbidden() {
+    void setPassword_WithWrongCurrent_ShouldReturnBadRequest() {
         NewPasswordDto passwordDto = new NewPasswordDto();
         passwordDto.setCurrentPassword("wrong123");
         passwordDto.setNewPassword("newPassword");
@@ -161,7 +161,7 @@ class UserControllerIntegrationTest extends AbstractIntegrationTest {
         ResponseEntity<Void> response = withAuth(userEmail, userPassword)
                 .postForEntity(baseUrl() + "/users/set_password", request, Void.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test


### PR DESCRIPTION
Issue #88: DIP-35 Исправить обработку ошибок при смене пароля

1. Обновлен `GlobalExceptionHandler` (значение возвращаемого статуса изменено с `FORBIDDEN` на `BAD_REQUEST`)
2. Обновлен тест `UserControllerIntegrationTest` (значение возвращаемого статуса изменено с `FORBIDDEN` на `BAD_REQUEST`)

Closes #88