### PR TITLE
Issue #89: DIP-36 Добавить глобальную обработку ошибок валидации

### DIFF
--- a/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
@@ -1,8 +1,12 @@
 package ru.skypro.homework.handler;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import ru.skypro.homework.exception.AdNotFoundException;
@@ -11,6 +15,11 @@ import ru.skypro.homework.exception.InvalidCurrentPasswordException;
 import ru.skypro.homework.exception.UnauthorizedAccessException;
 import ru.skypro.homework.exception.UserAlreadyExistsException;
 import ru.skypro.homework.exception.UserNotFoundException;
+
+import javax.validation.ConstraintViolationException;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -48,5 +57,44 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserAlreadyExistsException.class)
     public ResponseEntity<?> handleUserAlreadyExists(UserAlreadyExistsException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ValidationErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        List<Violation> violations = ex.getBindingResult().getFieldErrors().stream()
+                                       .map(error -> new Violation(error.getField(), error.getDefaultMessage()))
+                                       .collect(Collectors.toList());
+        return buildValidationErrorResponse(violations);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ValidationErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
+        List<Violation> violations = ex.getConstraintViolations().stream()
+                                       .map(violation -> new Violation(violation.getPropertyPath().toString(), violation.getMessage()))
+                                       .collect(Collectors.toList());
+        return buildValidationErrorResponse(violations);
+    }
+
+    private ResponseEntity<ValidationErrorResponse> buildValidationErrorResponse(List<Violation> violations) {
+        ValidationErrorResponse response = new ValidationErrorResponse(Instant.now().toString(), HttpStatus.BAD_REQUEST.value(),
+                "Validation failed", violations);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @Data
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ValidationErrorResponse {
+        private String timestamp;
+        private int status;
+        private String error;
+        private List<Violation> violations;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Violation {
+        private String field;
+        private String message;
     }
 }


### PR DESCRIPTION
Issue #89: DIP-36 Добавить глобальную обработку ошибок валидации

- Добавлена обработка `MethodArgumentNotValidException` (для `@Valid` в запросе)
- Добавлена обработка `ConstraintViolationException` (для валидации параметров пути при `@Validated`)
- Возвращает структурированный JSON с временем, статусом, общим сообщением и списком нарушений (поле + сообщение)
- Существующие обработчики (по типу `InvalidCurrentPasswordException`) остаются без изменений

Пример ответа при невалидных данных в формате JSON:
`{
   "timestamp": "2026-02-21T23:00:00Z",
   "status": 400,
   "error": "Validation failed",
   "violations": [
     { "field": "title", "message": "Заголовок не может быть пустым" },
     { "field": "price", "message": "Цена не может быть отрицательной" }
   ]
 }`

Closes #89