### PR TITLE
Issue #91: DIP-38 Создать контроллер для раздачи изображений

### DIFF
--- a/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
+++ b/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
@@ -22,7 +22,9 @@ public class WebSecurityConfig {
             "/v3/api-docs",
             "/webjars/**",
             "/login",
-            "/register"
+            "/register",
+            "/ads-images/**",
+            "/avatars/**"
     };
 
     @Bean

--- a/src/main/java/ru/skypro/homework/controller/image/ImageController.java
+++ b/src/main/java/ru/skypro/homework/controller/image/ImageController.java
@@ -1,0 +1,32 @@
+package ru.skypro.homework.controller.image;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import ru.skypro.homework.service.ImageService;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @GetMapping("/ads-images/{filename}")
+    public ResponseEntity<byte[]> getAdImage(@PathVariable String filename) {
+        ImageService.ImageData imageData = imageService.loadAdImage(filename);
+        return ResponseEntity.ok()
+                             .contentType(MediaType.parseMediaType(imageData.getContentType()))
+                             .body(imageData.getContent());
+    }
+
+    @GetMapping("/avatars/{filename}")
+    public ResponseEntity<byte[]> getAvatar(@PathVariable String filename) {
+        ImageService.ImageData imageData = imageService.loadAvatar(filename);
+        return ResponseEntity.ok()
+                             .contentType(MediaType.parseMediaType(imageData.getContentType()))
+                             .body(imageData.getContent());
+    }
+}

--- a/src/main/java/ru/skypro/homework/exception/ImageNotFoundException.java
+++ b/src/main/java/ru/skypro/homework/exception/ImageNotFoundException.java
@@ -1,0 +1,7 @@
+package ru.skypro.homework.exception;
+
+public class ImageNotFoundException extends RuntimeException {
+    public ImageNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ru/skypro/homework/exception/ImageReadException.java
+++ b/src/main/java/ru/skypro/homework/exception/ImageReadException.java
@@ -1,0 +1,7 @@
+package ru.skypro.homework.exception;
+
+public class ImageReadException extends RuntimeException {
+    public ImageReadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import ru.skypro.homework.exception.AdNotFoundException;
 import ru.skypro.homework.exception.CommentNotFoundException;
+import ru.skypro.homework.exception.ImageNotFoundException;
+import ru.skypro.homework.exception.ImageReadException;
 import ru.skypro.homework.exception.InvalidCurrentPasswordException;
 import ru.skypro.homework.exception.UnauthorizedAccessException;
 import ru.skypro.homework.exception.UserAlreadyExistsException;
@@ -85,6 +87,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<?> handleAccessDenied(AccessDeniedException e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+    @ExceptionHandler(ImageNotFoundException.class)
+    public ResponseEntity<?> handleImageNotFound(ImageNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(ImageReadException.class)
+    public ResponseEntity<?> handleImageRead(ImageReadException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
 
     @Data


### PR DESCRIPTION
Issue #91: DIP-38 Создать контроллер для раздачи изображений

1. Добавлен контроллер `ImageController` для загрузки изображений
2. Обновлен `ImageService` с логикой загрузки и передачи изображений
3. Добавлены два исключения для работы с изображениями `ImageNotFoundException` и `ImageReadException`
4. Обновлен `GlobalExceptionHandler` для перехвата новых исключений
5. Обновлен `WebSecurityConfig` - открыты эндпоинты для доступа к загрузке изображений без авторизации пользователя

Closes #91