### PR TITLE
Issue #92: DIP-39 Актуализировать интеграционные тесты

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ application.yml
 # Application specific
 uploads/
 tmp/
+/htmlReport/

--- a/src/main/java/ru/skypro/homework/controller/ad/AdController.java
+++ b/src/main/java/ru/skypro/homework/controller/ad/AdController.java
@@ -118,9 +118,8 @@ public class AdController {
             @ApiResponse(responseCode = "401", description = "Пользователь не авторизован")
     })
     @GetMapping("/me")
-    public ResponseEntity<AdsDto> getAdsMe(Authentication authentication) {
-        String email = authentication.getName();
-        return ResponseEntity.ok(adService.getAdsMe(email));
+    public ResponseEntity<AdsDto> getAdsMe() {
+        return ResponseEntity.ok(adService.getAdsMe());
     }
 
     @Operation(summary = "Обновление картинки объявления")

--- a/src/main/java/ru/skypro/homework/controller/comment/CommentController.java
+++ b/src/main/java/ru/skypro/homework/controller/comment/CommentController.java
@@ -52,10 +52,8 @@ public class CommentController {
     @PostMapping("/{adId}/comments")
     public ResponseEntity<CommentDto> addComment(
             @PathVariable Integer adId,
-            @Valid @RequestBody CreateOrUpdateCommentDto createComment,
-            Authentication authentication) {
-        String email = authentication.getName();
-        return ResponseEntity.ok(commentService.addComment(adId, email, createComment));
+            @Valid @RequestBody CreateOrUpdateCommentDto createComment) {
+        return ResponseEntity.ok(commentService.addComment(adId, createComment));
     }
 
     @Operation(summary = "Удаление комментария")
@@ -68,10 +66,8 @@ public class CommentController {
     @DeleteMapping("/{adId}/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(
             @PathVariable Integer adId,
-            @PathVariable Integer commentId,
-            Authentication authentication) {
-        String email = authentication.getName();
-        commentService.deleteComment(adId, commentId, email);
+            @PathVariable Integer commentId) {
+        commentService.deleteComment(adId, commentId);
         return ResponseEntity.ok().build();
     }
 
@@ -87,9 +83,7 @@ public class CommentController {
     public ResponseEntity<CommentDto> updateComment(
             @PathVariable Integer adId,
             @PathVariable Integer commentId,
-            @Valid @RequestBody CreateOrUpdateCommentDto updateComment,
-            Authentication authentication) {
-        String email = authentication.getName();
-        return ResponseEntity.ok(commentService.updateComment(adId, commentId, email, updateComment));
+            @Valid @RequestBody CreateOrUpdateCommentDto updateComment) {
+        return ResponseEntity.ok(commentService.updateComment(adId, commentId, updateComment));
     }
 }

--- a/src/main/java/ru/skypro/homework/controller/user/UserController.java
+++ b/src/main/java/ru/skypro/homework/controller/user/UserController.java
@@ -44,11 +44,8 @@ public class UserController {
             @ApiResponse(responseCode = "403", description = "Текущий пароль указан неверно")
     })
     @PostMapping("/set_password")
-    public ResponseEntity<Void> setPassword(
-            @Valid @RequestBody NewPasswordDto newPasswordDto,
-            Authentication authentication) {
-        String email = authentication.getName();
-        userService.setPassword(email, newPasswordDto);
+    public ResponseEntity<Void> setPassword(@Valid @RequestBody NewPasswordDto newPasswordDto) {
+        userService.setPassword(newPasswordDto);
         return ResponseEntity.ok().build();
     }
 
@@ -59,9 +56,8 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "Пользователь не авторизован")
     })
     @GetMapping("/me")
-    public ResponseEntity<UserDto> getUser(Authentication authentication) {
-        String email = authentication.getName();
-        return ResponseEntity.ok(userService.getUser(email));
+    public ResponseEntity<UserDto> getUser() {
+        return ResponseEntity.ok(userService.getUser());
     }
 
     @Operation(summary = "Обновление информации об авторизованном пользователе")
@@ -71,11 +67,8 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "Пользователь не авторизован")
     })
     @PatchMapping("/me")
-    public ResponseEntity<UpdateUserDto> updateUser(
-            @Valid @RequestBody UpdateUserDto updateUserDto,
-            Authentication authentication) {
-        String email = authentication.getName();
-        return ResponseEntity.ok(userService.updateUser(email, updateUserDto));
+    public ResponseEntity<UpdateUserDto> updateUser(@Valid @RequestBody UpdateUserDto updateUserDto) {
+        return ResponseEntity.ok(userService.updateUser(updateUserDto));
     }
 
     @Operation(summary = "Обновление аватара авторизованного пользователя")
@@ -84,11 +77,8 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "Пользователь не авторизован")
     })
     @PatchMapping(value = "/me/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> updateUserImage(
-            @RequestParam("image") MultipartFile image,
-            Authentication authentication) {
-        String email = authentication.getName();
-        userService.updateUserImage(email, image);
+    public ResponseEntity<Void> updateUserImage(@RequestParam("image") MultipartFile image) {
+        userService.updateUserImage(image);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ru/skypro/homework/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -97,6 +98,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ImageReadException.class)
     public ResponseEntity<?> handleImageRead(ImageReadException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<?> handleAuthenticationException(AuthenticationException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
 
     @Data

--- a/src/main/java/ru/skypro/homework/service/AdService.java
+++ b/src/main/java/ru/skypro/homework/service/AdService.java
@@ -52,10 +52,9 @@ public interface AdService {
     /**
      * Получение всех объявлений текущего пользователя.
      *
-     * @param email email автора
      * @return AdsDto с его объявлениями
      */
-    AdsDto getAdsMe(String email);
+    AdsDto getAdsMe();
 
     /**
      * Обновление картинки объявления.

--- a/src/main/java/ru/skypro/homework/service/CommentService.java
+++ b/src/main/java/ru/skypro/homework/service/CommentService.java
@@ -18,29 +18,26 @@ public interface CommentService {
      * Добавление комментария к объявлению
      *
      * @param adId идентификатор объявления
-     * @param email email автора комментария
      * @param createComment данные нового комментария
      * @return созданный комментарий
      */
-    CommentDto addComment(Integer adId, String email, CreateOrUpdateCommentDto createComment);
+    CommentDto addComment(Integer adId, CreateOrUpdateCommentDto createComment);
 
     /**
      * Удаление комментария
      *
      * @param adId идентификатор объявления
      * @param commentId идентификатор комментария
-     * @param email email текущего пользователя
      */
-    void deleteComment(Integer adId, Integer commentId, String email);
+    void deleteComment(Integer adId, Integer commentId);
 
     /**
      * Обновление комментария
      *
      * @param adId идентификатор объявления
      * @param commentId идентификатор комментария
-     * @param email email текущего пользователя
      * @param updateComment новые данные комментария
      * @return обновлённый комментарий
      */
-    CommentDto updateComment(Integer adId, Integer commentId, String email, CreateOrUpdateCommentDto updateComment);
+    CommentDto updateComment(Integer adId, Integer commentId, CreateOrUpdateCommentDto updateComment);
 }

--- a/src/main/java/ru/skypro/homework/service/CurrentUserService.java
+++ b/src/main/java/ru/skypro/homework/service/CurrentUserService.java
@@ -1,6 +1,9 @@
 package ru.skypro.homework.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
 import ru.skypro.homework.exception.UserNotFoundException;
 import ru.skypro.homework.model.UsersDao;
@@ -14,6 +17,30 @@ import ru.skypro.homework.repository.UserRepository;
 public class CurrentUserService {
 
     private final UserRepository userRepository;
+
+    /**
+     * Возвращает email текущего аутентифицированного пользователя.
+     * @throws AuthenticationException если пользователь не аутентифицирован (включая анонимного)
+     */
+    public String getCurrentUserEmail() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            throw new AuthenticationException("User not authenticated") {};
+        }
+        return authentication.getName();
+    }
+
+    /**
+     * Возвращает сущность текущего аутентифицированного пользователя.
+     * @throws AuthenticationException если пользователь не аутентифицирован
+     * @throws UserNotFoundException если пользователь не найден в БД
+     */
+    public UsersDao getCurrentUser() {
+        String email = getCurrentUserEmail();
+        return userRepository.findByEmail(email)
+                             .orElseThrow(() -> new UserNotFoundException("User not found with email: " + email));
+    }
 
     public UsersDao getUserByEmail(String email) {
         return userRepository.findByEmail(email)

--- a/src/main/java/ru/skypro/homework/service/UserService.java
+++ b/src/main/java/ru/skypro/homework/service/UserService.java
@@ -10,33 +10,29 @@ public interface UserService {
     /**
      * Получение информации о текущем пользователе.
      *
-     * @param email email (username) текущего пользователя
      * @return UserDto с данными пользователя
      */
-    UserDto getUser(String email);
+    UserDto getUser();
 
     /**
      * Обновление данных текущего пользователя (имя, фамилия, телефон).
      *
-     * @param email         email текущего пользователя
      * @param updateUserDto новые данные
      * @return обновлённые данные
      */
-    UpdateUserDto updateUser(String email, UpdateUserDto updateUserDto);
+    UpdateUserDto updateUser(UpdateUserDto updateUserDto);
 
     /**
      * Смена пароля текущего пользователя.
      *
-     * @param email          email текущего пользователя
      * @param newPasswordDto данные старого и нового пароля
      */
-    void setPassword(String email, NewPasswordDto newPasswordDto);
+    void setPassword(NewPasswordDto newPasswordDto);
 
     /**
      * Обновление аватара текущего пользователя.
      *
-     * @param email email текущего пользователя
      * @param image файл нового аватара
      */
-    void updateUserImage(String email, MultipartFile image);
+    void updateUserImage(MultipartFile image);
 }

--- a/src/main/java/ru/skypro/homework/service/impl/AdServiceImpl.java
+++ b/src/main/java/ru/skypro/homework/service/impl/AdServiceImpl.java
@@ -105,8 +105,8 @@ public class AdServiceImpl implements AdService {
 
     @Override
     @Transactional(readOnly = true)
-    public AdsDto getAdsMe(String email) {
-        UsersDao author = currentUserService.getUserByEmail(email);
+    public AdsDto getAdsMe() {
+        UsersDao author = currentUserService.getCurrentUser(); // получаем текущего пользователя
         List<AdsDao> ads = adRepository.findByAuthorId(author.getId());
         List<AdDto> adDtos = ads.stream()
                                 .map(adMapper::toAdDto)

--- a/src/main/java/ru/skypro/homework/service/impl/UserServiceImpl.java
+++ b/src/main/java/ru/skypro/homework/service/impl/UserServiceImpl.java
@@ -35,33 +35,33 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserDto getUser(String email) {
-        UsersDao user = currentUserService.getUserByEmail(email);
+    public UserDto getUser() {
+        UsersDao user = currentUserService.getCurrentUser();
         return userMapper.toUserDto(user);
     }
 
     @Override
-    public UpdateUserDto updateUser(String email, UpdateUserDto updateUserDto) {
-        UsersDao user = currentUserService.getUserByEmail(email);
+    public UpdateUserDto updateUser(UpdateUserDto updateUserDto) {
+        UsersDao user = currentUserService.getCurrentUser();
         userMapper.updateUserFromDto(updateUserDto, user);
         userRepository.save(user);
         return updateUserDto;
     }
 
     @Override
-    public void setPassword(String email, NewPasswordDto newPasswordDto) {
-        UsersDao user = currentUserService.getUserByEmail(email);
+    public void setPassword(NewPasswordDto newPasswordDto) {
+        UsersDao user = currentUserService.getCurrentUser();
         if (!passwordEncoder.matches(newPasswordDto.getCurrentPassword(), user.getPassword())) {
             throw new InvalidCurrentPasswordException("Current password is incorrect");
         }
         user.setPassword(passwordEncoder.encode(newPasswordDto.getNewPassword()));
         userRepository.save(user);
-        log.info("Password changed for user: {}", email);
+        log.info("Password changed for user: {}", user.getEmail());
     }
 
     @Override
-    public void updateUserImage(String email, MultipartFile image) {
-        UsersDao user = currentUserService.getUserByEmail(email);
+    public void updateUserImage(MultipartFile image) {
+        UsersDao user = currentUserService.getCurrentUser();
         String newImagePath = imageService.saveImage(image, avatarDir, "/avatars/");
         if (user.getImage() != null) {
             imageService.deleteImage(user.getImage(), avatarDir);

--- a/src/test/java/ru/skypro/homework/controller/image/ImageControllerIntegrationTest.java
+++ b/src/test/java/ru/skypro/homework/controller/image/ImageControllerIntegrationTest.java
@@ -1,0 +1,56 @@
+package ru.skypro.homework.controller.image;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import ru.skypro.homework.AbstractIntegrationTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ImageControllerIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private ImageController imageController;
+
+    private static final String AVATAR_DIR = "./target/test-avatars";
+    private static final String AD_IMAGE_DIR = "./target/test-ads-images";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        createImageDirectories();
+        // Создание тестовых файлы
+        Files.write(Paths.get(AVATAR_DIR, "avatar.jpg"), "fake-avatar-content".getBytes());
+        Files.write(Paths.get(AD_IMAGE_DIR, "ad.jpg"), "fake-ad-content".getBytes());
+    }
+
+    @Test
+    void getAvatar_ShouldReturnImage_WhenExists() {
+        ResponseEntity<byte[]> response = restTemplate.getForEntity(baseUrl() + "/avatars/avatar.jpg", byte[].class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void getAvatar_ShouldReturn404_WhenNotExists() {
+        ResponseEntity<byte[]> response = restTemplate.getForEntity(baseUrl() + "/avatars/nonexistent.jpg", byte[].class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void getAdImage_ShouldReturnImage_WhenExists() {
+        ResponseEntity<byte[]> response = restTemplate.getForEntity(baseUrl() + "/ads-images/ad.jpg", byte[].class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void getAdImage_ShouldReturn404_WhenNotExists() {
+        ResponseEntity<byte[]> response = restTemplate.getForEntity(baseUrl() + "/ads-images/nonexistent.jpg", byte[].class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Issue #92: DIP-39 Актуализировать интеграционные тесты

Комплексная работа по актуализации и расширению тестового покрытия + исправление ошибок разработки

1. Доработка `CurrentUserService`:
- Добавлен метод `getCurrentUserEmail()`, корректно обрабатывающий анонимного пользователя (anonymousUser).
- Метод `getCurrentUser()` теперь выбрасывает `AuthenticationException` при отсутствии аутентификации.
- Внедрено логирование для отслеживания текущего пользователя.
2. Рефакторинг контроллеров:
- Из методов `AdController`, `CommentController` и `UserController` удалён параметр `Authentication`.
- Вся логика получения текущего пользователя перенесена в соответствующие сервисы через `currentUserService.getCurrentUser()`.
3. Обновление сервисов:
- `AdServiceImpl`, `CommentServiceImpl`, `UserServiceImpl` переработаны для использования `getCurrentUser()`.
- Добавлены проверки прав доступа (автор/админ) с выбрасыванием `UnauthorizedAccessException`.
- Внедрены константы сообщений об ошибках (ExceptionMessages) для унификации и удобства поддержки.
4. Создание новых интеграционных тестов:
- `ImageControllerIntegrationTest` – проверка раздачи изображений (200 для существующих, 404 для отсутствующих).
- `AdControllerIntegrationTest` – добавлены тесты:
    - на 401 для всех защищённых методов (`addAd`, `updateAd`, `removeAd`, `updateImage`, `getAdsMe`);
    - на 404 для несуществующего объявления (`getAd`, `updateAd`, `removeAd`, `updateImage`);
    - на 403 при попытке изменения чужого объявления (`updateAd`, `removeAd`).
- `CommentControllerIntegrationTest` – добавлены тесты:
    - на 401 для всех защищённых методов (`addComment`, `deleteComment`, `updateComment`);
    - на 404 для несуществующего объявления или комментария (`getComments`, `addComment`, `deleteComment`, `updateComment`);
    - на 403 при попытке изменения чужого комментария (`deleteComment`, `updateComment`).
- `UserControllerIntegrationTest` – добавлены тесты на 401 для всех методов (`getUser`, `updateUser`, `setPassword`, `updateUserImage`).

Closes #92 